### PR TITLE
add f-log, f-log2 and f-log2c input color spaces

### DIFF
--- a/src/SpektraFilmPlugin.cpp
+++ b/src/SpektraFilmPlugin.cpp
@@ -2789,6 +2789,12 @@ const char *colorSpaceName(spektrafilm::ColorSpace colorSpace) {
       return "Canon Log3 CinemaGamut D55";
     case spektrafilm::ColorSpace::PanasonicVLogVGamut:
       return "Panasonic V-Log V-Gamut";
+    case spektrafilm::ColorSpace::FujiFLogFGamut:
+      return "Fujifilm F-Log F-Gamut";
+    case spektrafilm::ColorSpace::FujiFLog2FGamut:
+      return "Fujifilm F-Log2 F-Gamut";
+    case spektrafilm::ColorSpace::FujiFLog2CFGamutC:
+      return "Fujifilm F-Log2C F-Gamut C";
     case spektrafilm::ColorSpace::Aces2065_1:
       return "ACES2065-1";
     case spektrafilm::ColorSpace::AcesCg:
@@ -4915,6 +4921,9 @@ OfxStatus describeInContext(OfxImageEffectHandle effect, OfxPropertySetHandle) {
     "Canon Log2 CinemaGamut D55",
     "Canon Log3 CinemaGamut D55",
     "Panasonic V-Log V-Gamut",
+    "Fujifilm F-Log F-Gamut",
+    "Fujifilm F-Log2 F-Gamut",
+    "Fujifilm F-Log2C F-Gamut C",
     "ACES2065-1",
     "ACEScg",
     "ACEScct",
@@ -4930,7 +4939,10 @@ OfxStatus describeInContext(OfxImageEffectHandle effect, OfxPropertySetHandle) {
     "P3-D65 Gamma 2.2",
     "P3-D65 Gamma 2.6",
     "Rec.709 Gamma 2.2",
-    "Rec.709 Gamma 2.4"
+    "Rec.709 Gamma 2.4",
+    "Fujifilm F-Log F-Gamut",
+    "Fujifilm F-Log2 F-Gamut",
+    "Fujifilm F-Log2C F-Gamut C"
   };
   const char *rcmInputColorSpaces[] = {
     "DaVinci Intermediate WideGamut",

--- a/src/SpektraParameters.h
+++ b/src/SpektraParameters.h
@@ -120,6 +120,9 @@ enum class ColorSpace : int32_t {
   P3D65Gamma26 = 23,
   Rec709Gamma22 = 24,
   Rec709Gamma24 = 25,
+  FujiFLogFGamut = 26,
+  FujiFLog2FGamut = 27,
+  FujiFLog2CFGamutC = 28,
 };
 
 struct RenderParams {

--- a/src/SpektraProfileCurves.h
+++ b/src/SpektraProfileCurves.h
@@ -8,7 +8,7 @@
 
 namespace spektrafilm {
 
-constexpr uint32_t kSpektraColorSpaceCount = 26u;
+constexpr uint32_t kSpektraColorSpaceCount = 29u;
 constexpr uint32_t kSpektraColorTransferLutSize = 4096u;
 constexpr uint32_t kSpektraOutputGamutCompressionStride = 18u;
 constexpr uint32_t kSpektraOutputGamutCompressionElementCount =

--- a/tools/generate_profile_curves.py
+++ b/tools/generate_profile_curves.py
@@ -383,6 +383,33 @@ COLOR_SPACES = [
         "decode": lambda x: np.sign(x) * (np.abs(x) ** 2.4),
         "encode": lambda x: np.sign(x) * (np.abs(x) ** (1.0 / 2.4)),
     },
+    {
+        "key": "flog_fgamut",
+        "label": "Fujifilm F-Log F-Gamut",
+        "matrix_space": "F-Gamut",
+        "ofx": "flog_fgamut",
+        "transfer": TRANSFER_LUT,
+        "decode": lambda x: colour.models.log_decoding_FLog(x),
+        "encode": lambda x: colour.models.log_encoding_FLog(x),
+    },
+    {
+        "key": "flog2_fgamut",
+        "label": "Fujifilm F-Log2 F-Gamut",
+        "matrix_space": "F-Gamut",
+        "ofx": "flog2_fgamut",
+        "transfer": TRANSFER_LUT,
+        "decode": lambda x: colour.models.log_decoding_FLog2(x),
+        "encode": lambda x: colour.models.log_encoding_FLog2(x),
+    },
+    {
+        "key": "flog2c_fgamut_c",
+        "label": "Fujifilm F-Log2C F-Gamut C",
+        "matrix_space": "F-Gamut C",
+        "ofx": "flog2c_fgamut_c",
+        "transfer": TRANSFER_LUT,
+        "decode": lambda x: colour.models.log_decoding_FLog2(x),
+        "encode": lambda x: colour.models.log_encoding_FLog2(x),
+    },
 ]
 
 


### PR DESCRIPTION
This PR add Fujifilm F-Log, F-Log2 and F-Log2C to the input color spaces.

This allow Fujifilm users to use spektrafilm without needing a CST before.

To keep current edits working I added it to the end of the list of enums.